### PR TITLE
Make FIFO async iterable, add close() method

### DIFF
--- a/lib/fifo.ts
+++ b/lib/fifo.ts
@@ -1,12 +1,19 @@
 import StaticFIFO from "./static.ts";
 
+export const END = Symbol("Stream ended.");
+export const ERROR = Symbol("Stream errored.");
+
+export type Enqueueable<T> = T | Promise<T> | typeof END | typeof ERROR;
+export type Resolver<T> = (value: T | PromiseLike<T>) => void;
+
 export class FIFO<T> {
-    private head: StaticFIFO<T>;
-    private tail: StaticFIFO<T>;
+    private head: StaticFIFO<Enqueueable<T>>;
+    private tail: StaticFIFO<Enqueueable<T>>;
     public length: number;
+    private resolve: null | Resolver<Enqueueable<T>> = null;
 
     constructor(capacity: number = 16) {
-        this.head = new StaticFIFO<T>(capacity);
+        this.head = new StaticFIFO<Enqueueable<T>>(capacity);
         this.tail = this.head;
         this.length = 0;
     }
@@ -17,8 +24,14 @@ export class FIFO<T> {
         this.length = 0;
     }
 
-    public push(value: T) {
+    public push(value: Enqueueable<T>) {
         ++this.length;
+        
+        if (this.resolve) {
+            this.resolve(value); 
+            this.resolve = null;
+            return;
+        }
 
         if (!this.head.push(value)) {
             const prev = this.head;
@@ -55,6 +68,27 @@ export class FIFO<T> {
 
         return value;
     }
+    
+    close() {
+        this.push(END);
+    }
+    
+      async *[Symbol.asyncIterator]() {
+        while (true) {
+            const shifted = this.shift();
+    
+            const value = shifted ||
+            await new Promise<Enqueueable<T>>((res) => {
+                this.resolve = res;
+            });
+    
+            if (value === END || value === ERROR) {
+                break;
+            }
+    
+            yield value;
+        }
+      }
 }
 
 export default FIFO;

--- a/readme.md
+++ b/readme.md
@@ -17,4 +17,10 @@ console.log(queue.shift()); // 2
 console.log(queue.shift()); // 3
 
 console.log(queue.shift()); // undefined
+
+// Can be used as an async iterable
+
+for await (const value of queue) {
+	console.log(value);
+}
 ```

--- a/tests/fifo.test.ts
+++ b/tests/fifo.test.ts
@@ -36,3 +36,26 @@ Deno.test("Big", () => {
 
     assertEquals(queue.length, 0);
 });
+
+Deno.test("AsyncIterable", async () => {
+    const queue = new FIFO<number>();
+    
+    const values: number[] = [];
+    
+    (async () => {
+        for await (const value of queue) {
+            values.push(value);
+        }  
+    })()
+    
+    queue.push(1);
+    queue.push(2);
+    queue.push(3);
+    queue.close();
+    
+    await new Promise((res) => {
+        setTimeout(res, 0);
+    })
+    
+    assertEquals(values, [1, 2, 3])
+})

--- a/tests/fifo.test.ts
+++ b/tests/fifo.test.ts
@@ -51,11 +51,11 @@ Deno.test("AsyncIterable", async () => {
     queue.push(1);
     queue.push(2);
     queue.push(3);
-    queue.close();
     
     await new Promise((res) => {
         setTimeout(res, 0);
     })
     
-    assertEquals(values, [1, 2, 3])
+    assertEquals(values, [1, 2, 3]);
+    assertEquals(queue.length, 0);
 })


### PR DESCRIPTION
Hello! This is a pull request which makes `FIFO` asynchronously iterable, so you can do this: 

```ts
for await (const value of queue) {
	console.log(value);
}
```

Additionally, there is an extra `close` method added to the FIFO which allows you to signal that the queue is over and that any iterations should break.

The features can be completely ignored, and the FIFO can be used exactly the same way as before.