### PR TITLE
Add benchmarks

### DIFF
--- a/tests/bench.ts
+++ b/tests/bench.ts
@@ -1,0 +1,47 @@
+import FIFO from "../lib/fifo.ts";
+
+const AMOUNT = 10000;
+
+Deno.bench("Array push", { group: "push", baseline: true }, () => {
+  const array = [];
+
+  for (let i = 0; i < AMOUNT; i++) {
+    array.push(i);
+  }
+});
+
+Deno.bench("Array shift", { group: "shift", baseline: true }, (ctx) => {
+  const array = [];
+
+  for (let i = 0; i < AMOUNT; i++) {
+    array.push(i);
+  }
+
+  ctx.start();
+  for (let i = 0; i < AMOUNT; i++) {
+    array.shift();
+  }
+  ctx.end();
+});
+
+Deno.bench("FIFO push", { group: "push" }, () => {
+  const fifo = new FIFO<number>();
+
+  for (let i = 0; i < AMOUNT; i++) {
+    fifo.push(i);
+  }
+});
+
+Deno.bench("FIFO shift", { group: "shift" }, (ctx) => {
+  const fifo = new FIFO<number>();
+
+  for (let i = 0; i < AMOUNT; i++) {
+    fifo.push(i);
+  }
+
+  ctx.start();
+  for (let i = 0; i < AMOUNT; i++) {
+    fifo.shift();
+  }
+  ctx.end();
+});


### PR DESCRIPTION
Added a benchmark which can be run with `deno bench tests/bench.ts`. This benchmark compares the performance of `push` and `shift` between `Array` and `FIFO`.


On my machine:

```
Array push       36.27 µs/iter      27,568.7  (23.57 µs … 486.95 µs)  32.23 µs 188.61 µs 210.29 µs
FIFO push        67.17 µs/iter      14,888.3  (51.85 µs … 752.19 µs)  64.64 µs 237.92 µs 276.81 µs

summary
  Array push
   1.85x faster than FIFO push

Array shift     791.25 µs/iter       1,263.8   (720.46 µs … 1.38 ms) 803.21 µs   1.18 ms   1.19 ms
FIFO shift       63.46 µs/iter      15,758.7  (58.13 µs … 228.91 µs)  59.51 µs    149 µs 170.27 µs

summary
  Array shift
   12.47x slower than FIFO shift
```