### PR TITLE
fix: add test for awaiting result of generator.

### DIFF
--- a/lib/fifo.ts
+++ b/lib/fifo.ts
@@ -108,7 +108,9 @@ export class FIFO<T> {
     public async *[Symbol.asyncIterator](): AsyncGenerator<T> {
         while (true) {
             if (this.length) {
-                yield this.shift()!;
+                const value = this.shift()!;
+                if (!value) break;
+                yield value;
                 continue;
             }
 

--- a/tests/fifo.test.ts
+++ b/tests/fifo.test.ts
@@ -57,7 +57,7 @@ Deno.test("AsyncIterator", async () => {
     const queue = new FIFO<number>();
     const values: number[] = [];
 
-    (async () => {
+    const promise = (async () => {
         for await (const value of queue) {
             values.push(value);
         }
@@ -68,6 +68,8 @@ Deno.test("AsyncIterator", async () => {
     queue.push(3);
 
     await new Promise(resolve => setTimeout(resolve));
+
+    await promise
 
     assertEquals(values, [1, 2, 3]);
     assertEquals(queue.length, 0);


### PR DESCRIPTION
Hey there! I was having an error in a test in a library I was working with ( [earthstar](https://github.com/earthstar-project/earthstar) ), and I've tracked the issue down to a minimum reproducible example with the `FIFO` class.

This PR tweaks one of the tests to demonstrate the issue. The test fails with:

```
error: Promise resolution is still pending but the event loop has already resolved.
```

I'm not sure if this demonstrates an actual problem, or if it's just a nuance in the way that the taskrunner executes.

I'd appreciate any guidance on this!